### PR TITLE
Use `gen-flow-files` to generate Flow declarations

### DIFF
--- a/dist/index.js.flow
+++ b/dist/index.js.flow
@@ -1,97 +1,25 @@
 /* @flow */
-
-import first from 'lodash/first'
-import last from 'lodash/last'
-import map from 'lodash/map'
-import flatten from 'lodash/flatten'
-import {type ReadOnlyMapIterator} from 'lodash'
-import {fromJust} from '@freckle/maybe'
-
-class NonEmpty {}
-
-export type NonEmptyArray<T> = Array<T> & NonEmpty
-
-export function mkNonEmpty<T>(array: Array<T>): ?NonEmptyArray<T> {
-  return array.length === 0 ? null : ((array: any): NonEmptyArray<T>)
-}
-
-export function mkNonEmptyFromJust<T>(array: Array<T>): NonEmptyArray<T> {
-  return fromJust(mkNonEmpty(array), 'Array that should have been non-empty was empty')
-}
-
-export function mkNonEmptySingleton<T>(elem: T): NonEmptyArray<T> {
-  return fromJust(
-    mkNonEmpty([elem]),
-    "This definitely shouldn't happen! We created a non empty array from an element"
-  )
-}
-
-export function mkNonEmptyFromHead<T>(head: T, tail: Array<T>): NonEmptyArray<T> {
-  return fromJust(
-    mkNonEmpty([head].concat(tail)),
-    "This definitely shouldn't happen! We created a non empty array from the head element and an array"
-  )
-}
-
-export function mkNonEmptyFromLast<T>(init: Array<T>, last: T): NonEmptyArray<T> {
-  return fromJust(
-    mkNonEmpty(init.concat([last])),
-    "This definitely shouldn't happen! We created a non empty array from the last element and an array"
-  )
-}
-
-export function mapOnNonEmpty<T, U>(
-  nonEmpty: NonEmptyArray<T>,
-  f: ReadOnlyMapIterator<T, U>
-): NonEmptyArray<U> {
-  return fromJust(mkNonEmpty(map(nonEmpty, f)), 'Array that should have been non-empty was empty')
-}
-
-export function lastOnNonEmpty<T>(array: NonEmptyArray<T>): T {
-  const lastElem = last(array)
-  if (lastElem === null || lastElem === undefined) {
-    throw new TypeError(
-      "This definitely shouldn't happen! The types declare this array to be non-empty"
-    )
-  } else {
-    return lastElem
-  }
-}
-
-export function headOnNonEmpty<T>(array: NonEmptyArray<T>): T {
-  const firstElem = first(array)
-  if (firstElem === null || firstElem === undefined) {
-    throw new TypeError(
-      "This definitely shouldn't happen! The types declare this array to be non-empty"
-    )
-  } else {
-    return firstElem
-  }
-}
-
-export function tailOnNonEmpty<T>(array: NonEmptyArray<T>): Array<T> {
-  return array.slice(1)
-}
-
-export function initOnNonEmpty<T>(array: NonEmptyArray<T>): Array<T> {
-  return array.slice(0, -1)
-}
-
-export function nonEmptyToArray<T>(array: NonEmptyArray<T>): Array<T> {
-  return (array: Array<T>)
-}
-
-export function unconsOnNonEmpty<T>(array: NonEmptyArray<T>): [T, Array<T>] {
-  return [headOnNonEmpty(array), tailOnNonEmpty(array)]
-}
-
-export function flattenOnNonEmpty<T>(array: NonEmptyArray<NonEmptyArray<T>>): NonEmptyArray<T> {
-  return fromJust(
-    mkNonEmpty(flatten(nonEmptyToArray(array))),
-    'Array that should have been non-empty was empty'
-  )
-}
-
+import first from 'lodash/first';
+import last from 'lodash/last';
+import map from 'lodash/map';
+import flatten from 'lodash/flatten';
+import { type ReadOnlyMapIterator } from 'lodash';
+import { fromJust } from '@freckle/maybe';
+declare class NonEmpty {}
+export type NonEmptyArray<T> = Array<T> & NonEmpty;
+declare export function mkNonEmpty<T>(array: Array<T>): ?NonEmptyArray<T>;
+declare export function mkNonEmptyFromJust<T>(array: Array<T>): NonEmptyArray<T>;
+declare export function mkNonEmptySingleton<T>(elem: T): NonEmptyArray<T>;
+declare export function mkNonEmptyFromHead<T>(head: T, tail: Array<T>): NonEmptyArray<T>;
+declare export function mkNonEmptyFromLast<T>(init: Array<T>, last: T): NonEmptyArray<T>;
+declare export function mapOnNonEmpty<T, U>(nonEmpty: NonEmptyArray<T>, f: ReadOnlyMapIterator<T, U>): NonEmptyArray<U>;
+declare export function lastOnNonEmpty<T>(array: NonEmptyArray<T>): T;
+declare export function headOnNonEmpty<T>(array: NonEmptyArray<T>): T;
+declare export function tailOnNonEmpty<T>(array: NonEmptyArray<T>): Array<T>;
+declare export function initOnNonEmpty<T>(array: NonEmptyArray<T>): Array<T>;
+declare export function nonEmptyToArray<T>(array: NonEmptyArray<T>): Array<T>;
+declare export function unconsOnNonEmpty<T>(array: NonEmptyArray<T>): [T, Array<T>];
+declare export function flattenOnNonEmpty<T>(array: NonEmptyArray<NonEmptyArray<T>>): NonEmptyArray<T>;
 export default {
   mkNonEmpty,
   mkNonEmptySingleton,
@@ -103,4 +31,4 @@ export default {
   unconsOnNonEmpty,
   initOnNonEmpty,
   nonEmptyToArray
-}
+};

--- a/dist/index.test.js.flow
+++ b/dist/index.test.js.flow
@@ -1,124 +1,98 @@
 /* @flow */
-
-import {
-  mkNonEmpty,
-  mkNonEmptySingleton,
-  mkNonEmptyFromHead,
-  mkNonEmptyFromLast,
-  lastOnNonEmpty,
-  headOnNonEmpty,
-  tailOnNonEmpty,
-  initOnNonEmpty,
-  type NonEmptyArray
-} from '.'
-
+import { mkNonEmpty, mkNonEmptySingleton, mkNonEmptyFromHead, mkNonEmptyFromLast, lastOnNonEmpty, headOnNonEmpty, tailOnNonEmpty, initOnNonEmpty, type NonEmptyArray } from '.';
 describe('NonEmpty', () => {
   describe('mkNonEmpty', () => {
     test('should return null when passing empty array', () => {
-      const arr = mkNonEmpty([])
-      expect(arr).toEqual(null)
-    })
-
+      const arr = mkNonEmpty([]);
+      expect(arr).toEqual(null);
+    });
     test('should return a non empty array when passing an array with elements', () => {
-      const neArr = mkNonEmpty([1, 2])
-      expect(neArr).toEqual([1, 2])
-      expect(Array.isArray(neArr)).toBeTruthy()
-    })
-  })
-
+      const neArr = mkNonEmpty([1, 2]);
+      expect(neArr).toEqual([1, 2]);
+      expect(Array.isArray(neArr)).toBeTruthy();
+    });
+  });
   describe('mkNonEmptySingleton', () => {
     test('should return a non empty array when passing an element', () => {
-      const neArr = mkNonEmptySingleton(1)
-      expect(neArr).toEqual([1])
-      expect(Array.isArray(neArr)).toBeTruthy()
-    })
-  })
-
+      const neArr = mkNonEmptySingleton(1);
+      expect(neArr).toEqual([1]);
+      expect(Array.isArray(neArr)).toBeTruthy();
+    });
+  });
   describe('mkNonEmptyFromHead', () => {
     test('should return a non empty array when passing an element and an empty array', () => {
-      const neArr = mkNonEmptyFromHead(1, [])
-      expect(neArr).toEqual([1])
-      expect(Array.isArray(neArr)).toBeTruthy()
-    })
-
+      const neArr = mkNonEmptyFromHead(1, []);
+      expect(neArr).toEqual([1]);
+      expect(Array.isArray(neArr)).toBeTruthy();
+    });
     test('should return a non empty array when passing an element and an array', () => {
-      const neArr = mkNonEmptyFromHead(1, [2])
-      expect(neArr).toEqual([1, 2])
-      expect(Array.isArray(neArr)).toBeTruthy()
-    })
-  })
-
+      const neArr = mkNonEmptyFromHead(1, [2]);
+      expect(neArr).toEqual([1, 2]);
+      expect(Array.isArray(neArr)).toBeTruthy();
+    });
+  });
   describe('mkNonEmptyFromLast', () => {
     test('should return a non empty array when passing an element and an empty array', () => {
-      const neArr = mkNonEmptyFromLast([], 2)
-      expect(neArr).toEqual([2])
-      expect(Array.isArray(neArr)).toBeTruthy()
-    })
-
+      const neArr = mkNonEmptyFromLast([], 2);
+      expect(neArr).toEqual([2]);
+      expect(Array.isArray(neArr)).toBeTruthy();
+    });
     test('should return a non empty array when passing an element and an array', () => {
-      const neArr = mkNonEmptyFromLast([1], 2)
-      expect(neArr).toEqual([1, 2])
-      expect(Array.isArray(neArr)).toBeTruthy()
-    })
-  })
-
+      const neArr = mkNonEmptyFromLast([1], 2);
+      expect(neArr).toEqual([1, 2]);
+      expect(Array.isArray(neArr)).toBeTruthy();
+    });
+  });
   describe('lastOnNonEmpty', () => {
     test('should return a the last element of a non empty array', () => {
-      const neArr = mkNonEmptyFromHead(1, [2])
-      const res = lastOnNonEmpty(neArr)
-      expect(res).toEqual(2)
-    })
-
+      const neArr = mkNonEmptyFromHead(1, [2]);
+      const res = lastOnNonEmpty(neArr);
+      expect(res).toEqual(2);
+    });
     test('should throw an error when trying to get the last element on an empty array', () => {
       // Here we need to force flow to create an invalid empty array
-      const invalidNEArr: NonEmptyArray<any> = ([]: any)
-      expect(() => lastOnNonEmpty(invalidNEArr)).toThrow()
-    })
-  })
-
+      const invalidNEArr: NonEmptyArray<any> = ([]: any);
+      expect(() => lastOnNonEmpty(invalidNEArr)).toThrow();
+    });
+  });
   describe('headOnNonEmpty', () => {
     test('should return a the first element of a non empty array', () => {
-      const neArr = mkNonEmptyFromHead(1, [2])
-      const res = headOnNonEmpty(neArr)
-      expect(res).toEqual(1)
-    })
-
+      const neArr = mkNonEmptyFromHead(1, [2]);
+      const res = headOnNonEmpty(neArr);
+      expect(res).toEqual(1);
+    });
     test('should throw an error when trying to get the first element on an empty array', () => {
       // Here we need to force flow to create an invalid empty array
-      const invalidNEArr: NonEmptyArray<any> = ([]: any)
-      expect(() => headOnNonEmpty(invalidNEArr)).toThrow()
-    })
-  })
-
+      const invalidNEArr: NonEmptyArray<any> = ([]: any);
+      expect(() => headOnNonEmpty(invalidNEArr)).toThrow();
+    });
+  });
   describe('tailOnNonEmpty', () => {
     test('should return a the tail of a non empty array', () => {
-      const neArr = mkNonEmptyFromHead(1, [2])
-      const res = tailOnNonEmpty(neArr)
-      expect(Array.isArray(res)).toBeTruthy()
-      expect(res).toEqual([2])
-    })
-
+      const neArr = mkNonEmptyFromHead(1, [2]);
+      const res = tailOnNonEmpty(neArr);
+      expect(Array.isArray(res)).toBeTruthy();
+      expect(res).toEqual([2]);
+    });
     test('should return an empty tail when non empty array contains only one element', () => {
-      const neArr = mkNonEmptySingleton(1)
-      const res = tailOnNonEmpty(neArr)
-      expect(Array.isArray(res)).toBeTruthy()
-      expect(res).toEqual([])
-    })
-  })
-
+      const neArr = mkNonEmptySingleton(1);
+      const res = tailOnNonEmpty(neArr);
+      expect(Array.isArray(res)).toBeTruthy();
+      expect(res).toEqual([]);
+    });
+  });
   describe('initOnNonEmpty', () => {
     test('should return a the tail of a non empty array', () => {
-      const neArr = mkNonEmptyFromHead(1, [2])
-      const res = initOnNonEmpty(neArr)
-      expect(Array.isArray(res)).toBeTruthy()
-      expect(res).toEqual([1])
-    })
-
+      const neArr = mkNonEmptyFromHead(1, [2]);
+      const res = initOnNonEmpty(neArr);
+      expect(Array.isArray(res)).toBeTruthy();
+      expect(res).toEqual([1]);
+    });
     test('should return an empty list when non empty array contains only one element', () => {
-      const neArr = mkNonEmptySingleton(1)
-      const res = initOnNonEmpty(neArr)
-      expect(Array.isArray(res)).toBeTruthy()
-      expect(res).toEqual([])
-    })
-  })
-})
+      const neArr = mkNonEmptySingleton(1);
+      const res = initOnNonEmpty(neArr);
+      expect(Array.isArray(res)).toBeTruthy();
+      expect(res).toEqual([]);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,30 +1,32 @@
 {
-    "name": "@freckle/non-empty",
-    "version": "1.0.0",
-    "description": "Construct and operate on non-empry arrays with type-safety",
-    "main": "./dist/index.js",
-    "repository": "https://github.com/freckle/non-empty-js.git",
-    "author": "Freckle",
-    "license": "MIT",
-    "scripts": {
-        "build": "babel src -d dist --ignore \"src/**/*.test.js\" &&flow-copy-source -i \"src/**/*.test.js\" src dist",
-        "test": "jest",
-        "flow": "flow",
-        "format": "prettier --write 'src/**/*.js'",
-        "check-git-clean": "./check-git-clean.sh"
-    },
-    "dependencies": {
-        "@freckle/maybe": "https://github.com/freckle/maybe-js.git#v2.1.0",
-        "lodash": "4.17.21"
-    },
-    "devDependencies": {
-        "@babel/cli": "^7.17.0",
-        "@babel/core": "^7.17.0",
-        "@babel/preset-env": "^7.16.11",
-        "@babel/preset-flow": "^7.16.7",
-        "flow-bin": "0.110.0",
-        "flow-copy-source": "2.0.9",
-        "jest": "^27.4.7",
-        "prettier": "^2.5.1"
-    }
+  "name": "@freckle/non-empty",
+  "version": "1.0.0",
+  "description": "Construct and operate on non-empry arrays with type-safety",
+  "main": "./dist/index.js",
+  "repository": "https://github.com/freckle/non-empty-js.git",
+  "author": "Freckle",
+  "license": "MIT",
+  "scripts": {
+    "build": "babel src -d dist --ignore \"src/**/*.test.js\" && yarn build:flow",
+    "build:flow": "gen-flow-files src --out-dir dist",
+    "test": "jest",
+    "flow": "flow",
+    "format": "prettier --write 'src/**/*.js'",
+    "check-git-clean": "./check-git-clean.sh"
+  },
+  "dependencies": {
+    "@freckle/maybe": "https://github.com/freckle/maybe-js.git#v2.1.0",
+    "gen-flow-files": "^0.5.0",
+    "lodash": "4.17.21"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.17.0",
+    "@babel/core": "^7.17.0",
+    "@babel/preset-env": "^7.16.11",
+    "@babel/preset-flow": "^7.16.7",
+    "flow-bin": "0.110.0",
+    "flow-copy-source": "2.0.9",
+    "jest": "^27.4.7",
+    "prettier": "^2.5.1"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,6 +38,11 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.17.7.tgz#078d8b833fbbcc95286613be8c716cef2b519fa2"
   integrity sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==
 
+"@babel/compat-data@^7.17.10":
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.17.10.tgz#711dc726a492dfc8be8220028b1b92482362baab"
+  integrity sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw==
+
 "@babel/core@^7.1.0", "@babel/core@^7.12.3", "@babel/core@^7.17.0", "@babel/core@^7.7.2", "@babel/core@^7.8.0":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.17.9.tgz#6bae81a06d95f4d0dec5bb9d74bbc1f58babdcfe"
@@ -59,6 +64,27 @@
     json5 "^2.2.1"
     semver "^6.3.0"
 
+"@babel/core@^7.7.5":
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.18.2.tgz#87b2fcd7cce9becaa7f5acebdc4f09f3dd19d876"
+  integrity sha512-A8pri1YJiC5UnkdrWcmfZTJTV85b4UXTAfImGmCfYmax4TR9Cw8sDS0MOk++Gp2mE/BefVJ5nwy5yzqNJbP/DQ==
+  dependencies:
+    "@ampproject/remapping" "^2.1.0"
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.18.2"
+    "@babel/helper-compilation-targets" "^7.18.2"
+    "@babel/helper-module-transforms" "^7.18.0"
+    "@babel/helpers" "^7.18.2"
+    "@babel/parser" "^7.18.0"
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.18.2"
+    "@babel/types" "^7.18.2"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.1"
+    semver "^6.3.0"
+
 "@babel/generator@^7.17.9", "@babel/generator@^7.7.2":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.9.tgz#f4af9fd38fa8de143c29fce3f71852406fc1e2fc"
@@ -67,6 +93,15 @@
     "@babel/types" "^7.17.0"
     jsesc "^2.5.1"
     source-map "^0.5.0"
+
+"@babel/generator@^7.18.2", "@babel/generator@^7.7.4":
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.2.tgz#33873d6f89b21efe2da63fe554460f3df1c5880d"
+  integrity sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==
+  dependencies:
+    "@babel/types" "^7.18.2"
+    "@jridgewell/gen-mapping" "^0.3.0"
+    jsesc "^2.5.1"
 
 "@babel/helper-annotate-as-pure@^7.16.7":
   version "7.16.7"
@@ -91,6 +126,16 @@
     "@babel/compat-data" "^7.17.7"
     "@babel/helper-validator-option" "^7.16.7"
     browserslist "^4.17.5"
+    semver "^6.3.0"
+
+"@babel/helper-compilation-targets@^7.18.2":
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.2.tgz#67a85a10cbd5fc7f1457fec2e7f45441dc6c754b"
+  integrity sha512-s1jnPotJS9uQnzFtiZVBUxe67CuBa679oWFHpxYYnTpRL/1ffhyX44R9uYiXoa/pLXcY9H2moJta0iaanlk/rQ==
+  dependencies:
+    "@babel/compat-data" "^7.17.10"
+    "@babel/helper-validator-option" "^7.16.7"
+    browserslist "^4.20.2"
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.16.10", "@babel/helper-create-class-features-plugin@^7.16.7", "@babel/helper-create-class-features-plugin@^7.17.6":
@@ -134,6 +179,11 @@
   integrity sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==
   dependencies:
     "@babel/types" "^7.16.7"
+
+"@babel/helper-environment-visitor@^7.18.2":
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.2.tgz#8a6d2dedb53f6bf248e31b4baf38739ee4a637bd"
+  integrity sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ==
 
 "@babel/helper-explode-assignable-expression@^7.16.7":
   version "7.16.7"
@@ -185,6 +235,20 @@
     "@babel/traverse" "^7.17.3"
     "@babel/types" "^7.17.0"
 
+"@babel/helper-module-transforms@^7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.18.0.tgz#baf05dec7a5875fb9235bd34ca18bad4e21221cd"
+  integrity sha512-kclUYSUBIjlvnzN2++K9f2qzYKFgjmnmjwL4zlmU5f8ZtzgWe8s0rUPSTGy2HmK4P8T52MQsS+HTQAgZd3dMEA==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/helper-simple-access" "^7.17.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/helper-validator-identifier" "^7.16.7"
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.18.0"
+    "@babel/types" "^7.18.0"
+
 "@babel/helper-optimise-call-expression@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz#a34e3560605abbd31a18546bd2aad3e6d9a174f2"
@@ -196,6 +260,11 @@
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz#aa3a8ab4c3cceff8e65eb9e73d87dc4ff320b2f5"
   integrity sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==
+
+"@babel/helper-plugin-utils@^7.17.12":
+  version "7.17.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.17.12.tgz#86c2347da5acbf5583ba0a10aed4c9bf9da9cf96"
+  integrity sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA==
 
 "@babel/helper-remap-async-to-generator@^7.16.8":
   version "7.16.8"
@@ -267,6 +336,15 @@
     "@babel/traverse" "^7.17.9"
     "@babel/types" "^7.17.0"
 
+"@babel/helpers@^7.18.2":
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.18.2.tgz#970d74f0deadc3f5a938bfa250738eb4ac889384"
+  integrity sha512-j+d+u5xT5utcQSzrh9p+PaJX94h++KN+ng9b9WEJq7pkUPAd61FGqhjuUEdfknb3E/uDBb7ruwEeKkIxNJPIrg==
+  dependencies:
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.18.2"
+    "@babel/types" "^7.18.2"
+
 "@babel/highlight@^7.16.7":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.17.9.tgz#61b2ee7f32ea0454612def4fccdae0de232b73e3"
@@ -280,6 +358,11 @@
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.9.tgz#9c94189a6062f0291418ca021077983058e171ef"
   integrity sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg==
+
+"@babel/parser@^7.18.0", "@babel/parser@^7.7.5":
+  version "7.18.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.4.tgz#6774231779dd700e0af29f6ad8d479582d7ce5ef"
+  integrity sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.16.7":
   version "7.16.7"
@@ -417,6 +500,14 @@
     "@babel/helper-plugin-utils" "^7.16.7"
     "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
 
+"@babel/plugin-proposal-throw-expressions@^7.7.4":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-throw-expressions/-/plugin-proposal-throw-expressions-7.16.7.tgz#d3512286f634a06f7271abecce752e1655b9ab03"
+  integrity sha512-BbjL/uDt7c+OKA7k2YbZIPtOb6qmrzXPybjqrGreP8wMMzTPKjjiK+moqgpElsIXv1XHmlk9PQWdOHD5sL93KA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/plugin-syntax-throw-expressions" "^7.16.7"
+
 "@babel/plugin-proposal-unicode-property-regex@^7.16.7", "@babel/plugin-proposal-unicode-property-regex@^7.4.4":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.16.7.tgz#635d18eb10c6214210ffc5ff4932552de08188a2"
@@ -473,6 +564,13 @@
   integrity sha512-UDo3YGQO0jH6ytzVwgSLv9i/CzMcUjbKenL67dTrAZPPv6GFAtDhe6jqnvmoKzC/7htNTohhos+onPtDMqJwaQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
+
+"@babel/plugin-syntax-flow@^7.7.4":
+  version "7.17.12"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.17.12.tgz#23d852902acd19f42923fca9d0f196984d124e73"
+  integrity sha512-B8QIgBvkIG6G2jgsOHQUist7Sm0EBLDCx8sen072IwqNuzMegZNXrYnSv77cYzA8mLDZAfQYqsLIhimiP1s2HQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.17.12"
 
 "@babel/plugin-syntax-import-meta@^7.8.3":
   version "7.10.4"
@@ -536,6 +634,13 @@
   integrity sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-syntax-throw-expressions@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-throw-expressions/-/plugin-syntax-throw-expressions-7.16.7.tgz#5fd64f4d58d653499cc1077bb58594e18da5a514"
+  integrity sha512-6Kw78ssLHIADvVsqLOLLxuxH4SG55A2tqn0Og2tQQq6X/06HBWLClg6quL+oTfyeVEsPnFYTSECkajseotTnbA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-syntax-top-level-await@^7.14.5", "@babel/plugin-syntax-top-level-await@^7.8.3":
   version "7.14.5"
@@ -941,10 +1046,34 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.18.0", "@babel/traverse@^7.18.2", "@babel/traverse@^7.7.4":
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.2.tgz#b77a52604b5cc836a9e1e08dca01cba67a12d2e8"
+  integrity sha512-9eNwoeovJ6KH9zcCNnENY7DMFwTU9JdGCFtqNLfUAqtUHRCOsTOqWoffosP8vKmNYeSBUv3yVJXjfd8ucwOjUA==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.18.2"
+    "@babel/helper-environment-visitor" "^7.18.2"
+    "@babel/helper-function-name" "^7.17.9"
+    "@babel/helper-hoist-variables" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/parser" "^7.18.0"
+    "@babel/types" "^7.18.2"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.17.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
   integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.18.0", "@babel/types@^7.18.2", "@babel/types@^7.7.4":
+  version "7.18.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.4.tgz#27eae9b9fd18e9dccc3f9d6ad051336f307be354"
+  integrity sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
@@ -1145,10 +1274,24 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@jridgewell/gen-mapping@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz#cf92a983c83466b8c0ce9124fadeaf09f7c66ea9"
+  integrity sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==
+  dependencies:
+    "@jridgewell/set-array" "^1.0.0"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz#68eb521368db76d040a6315cdb24bf2483037b9c"
   integrity sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==
+
+"@jridgewell/set-array@^1.0.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.1.tgz#36a6acc93987adcf0ba50c66908bd0b70de8afea"
+  integrity sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==
 
 "@jridgewell/sourcemap-codec@^1.4.10":
   version "1.4.11"
@@ -1159,6 +1302,14 @@
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
   integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/trace-mapping@^0.3.9":
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz#dcfe3e95f224c8fe97a87a5235defec999aa92ea"
+  integrity sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
@@ -1940,6 +2091,22 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+gen-flow-files@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/gen-flow-files/-/gen-flow-files-0.5.0.tgz#860c7fae28992a191d33de72fa2fa67d0e974f22"
+  integrity sha512-xzS9stax6Dgjbva5L1iSVHri6UzTx1Bu3mmKCVm1pIFoG+bozz0DAQgtOYi4PNVn2mnl3Vidh7RXTV3e2lEynQ==
+  dependencies:
+    "@babel/core" "^7.7.5"
+    "@babel/generator" "^7.7.4"
+    "@babel/parser" "^7.7.5"
+    "@babel/plugin-proposal-throw-expressions" "^7.7.4"
+    "@babel/plugin-syntax-flow" "^7.7.4"
+    "@babel/traverse" "^7.7.4"
+    "@babel/types" "^7.7.4"
+    glob "^7.1.6"
+    mkdirp "^0.5.1"
+    yargs "^15.0.2"
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -1985,6 +2152,18 @@ glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.6:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -2784,12 +2963,24 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@^3.0.4:
+minimatch@^3.0.4, minimatch@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
+mkdirp@^0.5.1:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
 
 ms@2.1.2:
   version "2.1.2"
@@ -3540,7 +3731,7 @@ yargs-parser@^20.2.2:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs@^15.0.1:
+yargs@^15.0.1, yargs@^15.0.2:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==


### PR DESCRIPTION
When the entire source is copied as a declaration, consuming projects have issues resolving the module imports via Flow, perhaps specifically imports that use Git repo (like `@freckle/maybe` here). Flow seems to use its own module resolution logic because it will complain about a missing module even when it resolves other modules in the same file path. For instance, `lodash` imports resolve fine.