### PR TITLE
Add `groupAllWith` and remove unnecessary `undefined` types/checks

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2,7 +2,7 @@ import { type ArrayIterator, type ListIterator } from 'lodash';
 declare class NonEmpty {
 }
 export declare type NonEmptyArray<T> = Array<T> & NonEmpty;
-export declare function mkNonEmpty<T>(array: Array<T>): NonEmptyArray<T> | undefined | null;
+export declare function mkNonEmpty<T>(array: Array<T>): NonEmptyArray<T> | null;
 export declare function mkNonEmptyFromJust<T>(array: Array<T>): NonEmptyArray<T>;
 export declare function mkNonEmptySingleton<T>(elem: T): NonEmptyArray<T>;
 export declare function mkNonEmptyFromHead<T>(head: T, tail: Array<T>): NonEmptyArray<T>;
@@ -15,6 +15,7 @@ export declare function initOnNonEmpty<T>(array: NonEmptyArray<T>): Array<T>;
 export declare function nonEmptyToArray<T>(array: NonEmptyArray<T>): Array<T>;
 export declare function unconsOnNonEmpty<T>(array: NonEmptyArray<T>): [T, Array<T>];
 export declare function flattenOnNonEmpty<T>(array: NonEmptyArray<NonEmptyArray<T>>): NonEmptyArray<T>;
+export declare function groupAllWith<A, B>(key: (a: A) => B, array: Array<A>): Array<NonEmptyArray<A>>;
 declare const _default: {
     mkNonEmpty: typeof mkNonEmpty;
     mkNonEmptySingleton: typeof mkNonEmptySingleton;

--- a/dist/index.js
+++ b/dist/index.js
@@ -3,11 +3,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.flattenOnNonEmpty = exports.unconsOnNonEmpty = exports.nonEmptyToArray = exports.initOnNonEmpty = exports.tailOnNonEmpty = exports.headOnNonEmpty = exports.lastOnNonEmpty = exports.mapOnNonEmpty = exports.mkNonEmptyFromLast = exports.mkNonEmptyFromHead = exports.mkNonEmptySingleton = exports.mkNonEmptyFromJust = exports.mkNonEmpty = void 0;
+exports.groupAllWith = exports.flattenOnNonEmpty = exports.unconsOnNonEmpty = exports.nonEmptyToArray = exports.initOnNonEmpty = exports.tailOnNonEmpty = exports.headOnNonEmpty = exports.lastOnNonEmpty = exports.mapOnNonEmpty = exports.mkNonEmptyFromLast = exports.mkNonEmptyFromHead = exports.mkNonEmptySingleton = exports.mkNonEmptyFromJust = exports.mkNonEmpty = void 0;
 const first_1 = __importDefault(require("lodash/first"));
 const last_1 = __importDefault(require("lodash/last"));
 const map_1 = __importDefault(require("lodash/map"));
 const flatten_1 = __importDefault(require("lodash/flatten"));
+const sortBy_1 = __importDefault(require("lodash/sortBy"));
 const maybe_1 = require("@freckle/maybe");
 class NonEmpty {
 }
@@ -37,7 +38,7 @@ function mapOnNonEmpty(nonEmpty, f) {
 exports.mapOnNonEmpty = mapOnNonEmpty;
 function lastOnNonEmpty(array) {
     const lastElem = (0, last_1.default)(array);
-    if (lastElem === null || lastElem === undefined) {
+    if (lastElem === undefined) {
         throw new TypeError("This definitely shouldn't happen! The types declare this array to be non-empty");
     }
     else {
@@ -47,7 +48,7 @@ function lastOnNonEmpty(array) {
 exports.lastOnNonEmpty = lastOnNonEmpty;
 function headOnNonEmpty(array) {
     const firstElem = (0, first_1.default)(array);
-    if (firstElem === null || firstElem === undefined) {
+    if (firstElem === undefined) {
         throw new TypeError("This definitely shouldn't happen! The types declare this array to be non-empty");
     }
     else {
@@ -75,6 +76,26 @@ function flattenOnNonEmpty(array) {
     return (0, maybe_1.fromJust)(mkNonEmpty((0, flatten_1.default)(nonEmptyToArray(array))), 'Array that should have been non-empty was empty');
 }
 exports.flattenOnNonEmpty = flattenOnNonEmpty;
+// https://hackage.haskell.org/package/base-4.18.1.0/docs/Data-List-NonEmpty.html#v:groupAllWith
+// `key` is used for sorting and equality comparisons. It is called at least
+// twice per item
+function groupAllWith(key, array) {
+    const sorted = (0, sortBy_1.default)(array, key);
+    const results = [];
+    sorted.forEach(v => {
+        const lastGroup = (0, last_1.default)(results);
+        // Item matches prior group so put it there
+        if (lastGroup !== undefined && key(headOnNonEmpty(lastGroup)) === key(v)) {
+            lastGroup.push(v);
+            // Item doesn't match prior group (or group doesn't exist), make new group
+        }
+        else {
+            results.push(mkNonEmptySingleton(v));
+        }
+    });
+    return results;
+}
+exports.groupAllWith = groupAllWith;
 exports.default = {
     mkNonEmpty,
     mkNonEmptySingleton,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   headOnNonEmpty,
   tailOnNonEmpty,
   initOnNonEmpty,
+  groupAllWith,
   type NonEmptyArray
 } from '.'
 
@@ -117,6 +118,29 @@ describe('NonEmpty', () => {
       const res = initOnNonEmpty(neArr)
       expect(Array.isArray(res)).toBeTruthy()
       expect(res).toEqual([])
+    })
+  })
+
+  describe('groupAllWith', () => {
+    it('returns empty given empty', () => expect(groupAllWith(x => x, [])).toEqual([]))
+
+    it('puts a singleton by itself', () => expect(groupAllWith(x => x, [42])).toEqual([[42]]))
+
+    it('respects the grouping key', () =>
+      expect(groupAllWith(x => x > 0, [1, -2, 2, 0, -1])).toEqual([[-2, 0, -1], [1, 2]]))
+
+    it('is stable', () => expect(groupAllWith(() => 42, [4, 2, 42])).toEqual([[4, 2, 42]]))
+
+    it('sorts by key', () =>
+      expect(groupAllWith(x => x, [99, -1, 0, 42, -42])).toEqual([[-42], [-1], [0], [42], [99]]))
+
+    // Not necessarily testing a desired behavior. More showing/documenting a
+    // consequence of the implementation that callers should be aware of.
+    it('calls key at least once per value', () => {
+      const key = jest.fn().mockReturnValue(42)
+      const values = [1, 2, 3]
+      groupAllWith(key, values);
+      expect(key.mock.calls.length).toBeGreaterThan(values.length)
     })
   })
 })


### PR DESCRIPTION
**Why?**

`lodash/groupBy` is abysmal. It returns an object which

 - necessarily converts the key values to `string` :(
 - has special `Dictionary` values which we inevitably want to convert to an array or `NonEmptyArray` anyways
 - if you want the key, in the original type, you've got to reach into the dictionary which requires you to deal with potential `undefined` values again even though it's impossible

I've noted needing this twice in recent efforts to convert our printables to the frontend (they rely on non-empty arrays heavily).

**Inspiration**

This is inspired by the Haskell function https://hackage.haskell.org/package/base-4.18.1.0/docs/Data-List-NonEmpty.html#v:groupAllWith

**`undefined`s**

I also removed some `undefined`s that are unnecessary and, thereby, yield unnecessary downstream checks.

These are safe removals and not a major change because
 - `first<T>`/`last<T>` always return `T | undefined` (`null` check is redundant)
 - `const a: null | undefined | T = mkNonEmpty<T>(...)` will still compile