### PR TITLE
Add more conventional `groupBy`

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,6 +9,7 @@ import {
   tailOnNonEmpty,
   initOnNonEmpty,
   groupAllWith,
+  groupBy,
   type NonEmptyArray
 } from '.'
 
@@ -150,6 +151,31 @@ describe('NonEmpty', () => {
       const values = [1, 2, 3]
       groupAllWith(key, values)
       expect(key.mock.calls.length).toBeGreaterThan(values.length)
+    })
+  })
+
+  describe(groupBy.name, () => {
+    it('returns empty given empty', () => expect(groupBy(x => x, [])).toEqual(new Map()))
+
+    it('puts a singleton by itself', () => expect(groupBy(x => x, [42])).toEqual(new Map([[42, [42]]])))
+
+    it('respects the grouping key', () =>
+     expect(groupBy(x => x > 0, [1 ,-1, -2, 2, 0])).toEqual(new Map([
+        [false,  [-1, -2, 0]],
+        [true, [1, 2]]
+      ]))
+    )
+
+    it('is stable', () => expect(groupBy(() => 42, [4, 2, 42])).toEqual(new Map([[42,  [4, 2, 42] ]])))
+
+    it('does not sort by key', () =>
+      expect(groupBy(x => x, [99, -1, 0, 42, -42])).toEqual(new Map([[99,  [99]], [-1, [-1]], [0, [0]], [42, [42]], [-42, [-42]]])))
+
+    it('calls key once per value', () => {
+      const key = jest.fn().mockReturnValue(42)
+      const values = [1, 2, 3]
+      groupBy(key, values)
+      expect(key.mock.calls.length).toEqual(values.length)
     })
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,26 @@ export function groupAllWith<A, B>(key: (a: A) => B, array: Array<A>): Array<Non
   return results
 }
 
+// Group results into non-empty groups. Note that the returned `Map` preserves
+// The order of the original array, within groups (it doesn't sort like
+//`groupAllWith`).
+export function groupBy<A, B>(key: (a: A) => B, array: Array<A>): Map<B, NonEmptyArray<A>> {
+  const results = new Map<B, NonEmptyArray<A>>()
+
+  for (const value of array) {
+    const k = key(value)
+    const accum = results.get(k)
+
+    if (accum === undefined) {
+      results.set(k, mkNonEmptySingleton(value))
+    } else {
+      accum.push(value)
+    }
+  }
+
+  return results
+}
+
 export default {
   mkNonEmpty,
   mkNonEmptySingleton,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3059,9 +3059,9 @@ prelude-ls@~1.1.2:
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
 prettier@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.2.tgz#03ff86dc7c835f2d2559ee76876a3914cec4a90a"
-  integrity sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
+  integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
 
 pretty-format@^27.0.0, pretty-format@^27.5.1:
   version "27.5.1"


### PR DESCRIPTION
**Why?**

`groupAllWith` helped make things more type-safe in a lot of places in our frontend.

The places it didn't totally improve were those that looked up a particular grouping by key (`groupAllWith` required a `.find(whereKeyMatches)`).

This should be useful in those places, providing a type-safe `groupBy`.